### PR TITLE
#162949207 Integrate Coveralls and Add README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/andela/ah-the-unsullied.svg?branch=develop)](https://travis-ci.org/andela/ah-the-unsullied)
+[![Coverage Status](https://coveralls.io/repos/github/andela/ah-the-unsullied/badge.svg)](https://coveralls.io/github/andela/ah-the-unsullied)
 
 Authors Haven - A Social platform for the creative at heart.
 =======


### PR DESCRIPTION
**What does this PR do?**

- Integrate Coveralls to the repo and add  Readme badge

**Description of the Task to be completed**

- Integrate ah-unsullied repo to Coveralls account
- Add Coveralls badge to Readme

**How should this be manually tested?**
- Navigate to the [Chore branch](https://github.com/andela/ah-the-unsullied/tree/ch-integrate-coveralls-162949207) to view the badge
- Navigate to [ah-unsullied on Coveralls](https://coveralls.io/github/andela/ah-the-unsullied) to view the test coverage

**What are the relevant pivotal tracker stories?**

- #162949207

**Screenshots (if appropriate)**

- N/A

