### PR TITLE
#162949214 Add social login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ python:
 services:
   - postgresql
 
+addons:
+  postgresql: '9.4'
+  apt:
+    packages:
+      - postgresql-server-dev-9.4
+
+
 env:
   - DJANGO_SETTINGS_MODULE="authors.settings"
 # Install dependencies
@@ -18,7 +25,6 @@ before_script:
 
 # Run tests
 script:
-  - python manage.py makemigrations
   - python manage.py migrate
   - pytest --cov-report term-missing --cov=authors/apps -p no:warnings
   - coverage report

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -1,11 +1,11 @@
-from django.urls import path
+from django.urls import path,include
 from .views import (
     LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView,
     PasswordReset, PasswordDone,
-    ActivationLinkView
+    ActivationLinkView, SocialAuth
 )
 
-""" Django 2.0 requires the app_name variable set when using include 
+""" Django 2.0 requires the app_name variable set when using include
 namespace
 """
 app_name = 'authentication'
@@ -14,6 +14,7 @@ urlpatterns = [
     path('user/', UserRetrieveUpdateAPIView.as_view(), name='user_update'),
     path('users/', RegistrationAPIView.as_view(), name="signup_url"),
     path('users/login/', LoginAPIView.as_view(), name="login_url"),
+    path('social', SocialAuth.as_view(), name="social_auth"),
     path('activate/account/<str:pk>/<str:token>',
          ActivationLinkView.as_view(), name="activate"
          ),

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -27,6 +27,7 @@ DEBUG = True
 ALLOWED_HOSTS = [
     '127.0.0.1',
     'localhost:8000',
+    'localhost',
     '.herokuapp.com'
 ]
 
@@ -45,6 +46,9 @@ INSTALLED_APPS = [
     'django_extensions',
     'rest_framework',
     'rest_framework_swagger',
+    'oauth2_provider',
+    'social_django',
+    'rest_framework_social_oauth2',
 
     'authors.apps.authentication',
     'authors.apps.core',
@@ -63,6 +67,8 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'social_django.middleware.SocialAuthExceptionMiddleware',
+
 ]
 
 ROOT_URLCONF = 'authors.urls'
@@ -78,6 +84,10 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                # OAuth
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
+
             ],
         },
     },
@@ -156,10 +166,69 @@ REST_FRAMEWORK = {
 
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
+        'rest_framework_social_oauth2.authentication.SocialAuthentication',
     ),
     'DEFAULT_PAGINATION_CLASS': 'authors.apps.core.pagination.CustomPagination',
     'PAGE_SIZE': 10
 }
+
+AUTHENTICATION_BACKENDS = (
+    # Google
+    'social_core.backends.google.GoogleOAuth2',
+
+    # Facebook OAuth2
+    'social_core.backends.facebook.FacebookAppOAuth2',
+    'social_core.backends.facebook.FacebookOAuth2',
+
+    # Twitter
+    'social_core.backends.twitter.TwitterOAuth',
+
+    # django-rest-framework-social-oauth2
+    'rest_framework_social_oauth2.backends.DjangoOAuth2',
+
+    # Django
+    'django.contrib.auth.backends.ModelBackend',
+
+)
+
+SOCIAL_AUTH_PIPELINE = (
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.social_user',
+    'social_core.pipeline.user.get_username',
+    'social_core.pipeline.social_auth.associate_by_email',
+    'social_core.pipeline.user.create_user',
+    'social_core.pipeline.social_auth.associate_user',
+    'social_core.pipeline.social_auth.load_extra_data',
+    'social_core.pipeline.user.user_details',
+)
+
+# Facebook configuration
+SOCIAL_AUTH_FACEBOOK_KEY = os.getenv('FACEBOOK_KEY')
+SOCIAL_AUTH_FACEBOOK_SECRET = os.getenv('FACEBOOK_SECRET')
+SOCIAL_AUTH_FACEBOOK_API_VERSION = '3.2'
+
+# Define SOCIAL_AUTH_FACEBOOK_SCOPE to get extra permissions from facebook.
+# Email is not sent by default, to get it,
+# you must request the email permission:
+SOCIAL_AUTH_FACEBOOK_SCOPE = ['email']
+SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {
+    'fields': 'id, name, email'
+}
+
+# Twitter configuration
+SOCIAL_AUTH_TWITTER_KEY = os.getenv('TWITTER_KEY')
+SOCIAL_AUTH_TWITTER_SECRET = os.getenv('TWITTER_SECRET_KEY')
+SOCIAL_AUTH_TWITTER_SCOPE = ['email']
+SOCIAL_AUTH_TWITTER_PROFILE_EXTRA_PARAMS = {
+    'fields': 'id, name, email'
+}
+
+# Google configuration
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.getenv('GOOGLE_KEY')
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.getenv('GOOGLE_SECRET')
+SOCIAL_AUTH_GOOGLE_OAUTH_SCOPE = ['email', 'username', 'password']
 
 # Jwt configuration
 JWT_AUTH = {

--- a/authors/tests/base_test.py
+++ b/authors/tests/base_test.py
@@ -23,6 +23,7 @@ class TestBase(APITestCase):
         self.user_url = reverse('authentication:signup_url')
         self.update_url = reverse('authentication:user_update')
         self.article_url = reverse('articles:article_create')
+        self.social_auth_url = reverse('authentication:social_auth')
 
         self.user_data = {
             "user": {
@@ -151,9 +152,28 @@ class TestBase(APITestCase):
             }
         }
 
+        self.invalid_payload = {
+            "access_token": "tjdjdj",
+            "access_token_secret": "dgdgdg"
+        }
+        self.no_token = {
+            "access_token_secret": "dgdgdg"
+        }
+        self.no_key = {
+            "access_token": "tjdjdj"
+        }
+        self.invalid_token = {
+            "provider":"google-oauth2",
+            "access_token": "tjdjdj"
+        }
+        self.invalid_provider = {
+            "provider":"guth2",
+            "access_token": "tjdjdj",
+        }
+        self.no_backend = {
+        }
     def get_token(self):
         """Register and login a user"""
-
         # register user
         self.client.post(
             self.user_url,

--- a/authors/tests/test_register.py
+++ b/authors/tests/test_register.py
@@ -106,3 +106,20 @@ class TestRegister(TestBase):
             format='json'
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_current_user(self):
+        self.client.post(
+            self.user_url,
+            self.user_data,
+            format='json'
+            )
+        self.client.get(self.get_verify_url(self.user_data))
+        res = self.client.post(
+                self.login_url,
+                data=json.dumps(self.user_data),
+                content_type='application/json'
+            )
+        token = res.data['token']
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+        response = self.client.get(self.update_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/authors/tests/test_social_auth.py
+++ b/authors/tests/test_social_auth.py
@@ -1,0 +1,34 @@
+import os
+from rest_framework.views import status
+
+# local imports
+from .base_test import TestBase
+
+
+class TestSocialAuth(TestBase):
+    """This class has tests social auth."""
+
+    def test_invalid_token(self):
+        """Test response when token is invalid"""
+        data = self.invalid_token
+        url = self.social_auth_url
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invalid_provider(self):
+        """Test response when user uses an invalid provider"""
+        data = self.invalid_provider
+        url = self.social_auth_url
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_login_with_twitter(self):
+        """Test login/signup using twitter keys"""
+        url = self.social_auth_url
+        data = {
+            "provider": "twitter",
+            "access_token": os.getenv('ACCESS_TOKEN'),
+            "access_token_secret": os.getenv('SECRET_TOKEN')
+        }
+        response = self.client.post(url, data=data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -30,5 +30,6 @@ urlpatterns = [
                                   namespace='profiles')),
     path('api/articles', include('authors.apps.articles.urls',
                                  namespace='articles')),
-    path('', schema_view)
+    path('', schema_view),
+    path('auth/', include('rest_framework_social_oauth2.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ cloudinary==1.15.0
 Pillow==5.4.1
 django-rest-swagger==2.1.0
 psycopg2==2.7.6.1
+django-rest-framework-social-oauth2==1.1.0


### PR DESCRIPTION
#### What does this PR do?

Add social authentication to the API

#### Description of Task to be completed?

* Enable Google, Facebook and Twitter login
* Add tests

#### How should this be manually tested?

1. Clone the repo: `git clone https://github.com/andela/ah-the-unsullied.git`
2. Cd into the cloned repo 
3. Git pull branch ft-social-auth-162949214
4. Set up a virtual environment and install requirements:
      ```
            python3 -m venv venv
            source venv/bin/activate
            pip3 install -r requirements.txt

     ```
5. Set up a .env file in the same level as the venv file and add the following:
      ```
           source venv/bin/activate
           export SECRET_KEY=""
           export DATABASE_URL=""
           export DJANGO_SETTINGS_MODULE='authors.settings'
           export CLOUDINARY_NAME=''
           export CLOUDINARY_KEY=''
           export CLOUDINARY_SECRET=''
           export HOST_PASSWORD=""
           export HOST_USER=""
           export SMTP_HOST=''
           export EMAIL_PORT=''
           export FACEBOOK_KEY='
           export FACEBOOK_SECRET=''
           export TWITTER_KEY=''
           export TWITTER_SECRET_KEY=''
           export GOOGLE_KEY=''
           export GOOGLE_SECRET=''
      ```
6. Then run: 
     ``` 
            source .env 
            ./manage.py migrate
            ./manage.py runserver
      ```
7. To test locally, you need an access token and add it to the postman body:
      ```
            {
               "provider":"",
               "access_token":""
                }

      ```
#### Any background context you want to provide?
You need the above keys from the admin.

#### What are the relevant pivotal tracker stories?
[162949206](#162949206)
#### Screenshots (if appropriate)
None
#### Questions: